### PR TITLE
Adds starting container log

### DIFF
--- a/example-apps/VulnerableServer/init.sh
+++ b/example-apps/VulnerableServer/init.sh
@@ -46,6 +46,7 @@ PORT=${PORT:-443}
 # DO NOT RUN THIS IN PRODUCTION
 # [ WARNING ]
 #
+printf "Starting VulnerableServer in ${PORT}" 
 while :
 do
    ncat -nvlp ${PORT} -e /bin/bash


### PR DESCRIPTION
Boring and simple change and maybe not necessary , but it helps to know if the container has started properly. 
We found this specially useful in Fargate + Cloudwatch is any easier way to know if the entrypoint is working as expected